### PR TITLE
Сonfigure Dockerfile and Docker Compose for Spring Boot and Database

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.idea/
+.git
+*.iml
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Step 1: Builder stage
+# Using an image of Java 17 and Maven
+FROM maven:3.8.4-openjdk-17-slim AS builder
+# Specifying the working directory for the build
+WORKDIR /app
+# Copying the configuration files
+COPY pom.xml .
+# Loading dependencies (this is cached if pom.xml does not change)
+RUN mvn dependency:go-offline
+# Copying the source code
+COPY src ./src
+# Building a project
+RUN mvn clean package -DskipTests
+# A new container for launching the application
+FROM openjdk:17-jdk-slim
+
+# Step 2: Production stage
+# Specifying the working directory
+WORKDIR /app
+# Копируем сгенерированный .jar из предыдущего контейнера
+COPY --from=builder /app/target/taskmanagement-0.0.1-SNAPSHOT.jar app.jar
+# Запускаем приложение
+CMD ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Task Management Project
+
+## Description
+This is a task management application that uses Spring Boot and PostgreSQL as the database.
+
+## Technologies:
+- Java 17
+- Spring Boot
+- PostgreSQL
+- Docker
+- Docker Compose
+
+## Local Setup
+
+### Steps:
+
+1. Clone the repository:
+   ```bash
+   git clone <repo_url>
+   cd <project_directory>
+   ```
+2. Build the project: 
+   Before running the project, make sure you have Maven installed and run the following command:
+   ```bash
+    mvn clean package
+   ```
+
+3. Build and start the containers using Docker Compose: 
+To build and run the application with the database, use the following command:
+   ```bash
+    docker-compose up --build
+   ```
+
+4. Access the application: 
+Once the containers are up and running, you can access the application at the following address:
+   ```bash
+   http://localhost:8080
+   ```
+
+5. To stop the containers:
+   ```bash
+   docker-compose down
+   ```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: postgres:16
+    container_name: task-db
+    environment:
+      POSTGRES_DB: taskdb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: Str0ngP@ssw0rd!2025
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  app:
+    build: .
+    container_name: task-app
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/taskdb
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: Str0ngP@ssw0rd!2025
+      JWT_SECRET: VGhpcyBpcyBhIHZlcnkgc2VjdXJlIGtleSB0aGF0IHlvdSBjYW4gc3RvcmUgc2FmZWx5Lg==
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
- Created a Dockerfile to build a container for the Spring Boot app.
- Added docker-compose.yml to set up the Spring Boot application and PostgreSQL database.
- Ensured that the app is connected to the database via Docker.
- Verified that the app and database run successfully with `docker-compose up`.
- Swagger UI is accessible at http://localhost:8080/swagger-ui.html.
- Added README.md file with instructions

Closes: #2