### PR TITLE
Add pagination support for GET /tasks endpoint

### DIFF
--- a/src/main/java/ru/effectivemobile/taskmanagement/config/SecurityConfig.java
+++ b/src/main/java/ru/effectivemobile/taskmanagement/config/SecurityConfig.java
@@ -42,9 +42,10 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/swagger-ui.html",
             "/webjars/**",
-            "/login",
+            "auth/login",
             "/",
-            "/register",
+            "auth/register",
+            "/auth/**"
     };
 
     /**

--- a/src/main/java/ru/effectivemobile/taskmanagement/controller/AuthController.java
+++ b/src/main/java/ru/effectivemobile/taskmanagement/controller/AuthController.java
@@ -2,6 +2,7 @@ package ru.effectivemobile.taskmanagement.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ru.effectivemobile.taskmanagement.dto.AuthResponseDTO;
@@ -15,19 +16,11 @@ import ru.effectivemobile.taskmanagement.service.impl.AuthServiceImpl;
  */
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 @Tag(name = "Authentication", description = "Endpoints for user registration and login")
 public class AuthController {
 
     private final AuthServiceImpl authService;
-
-    /**
-     * Constructor injection of authentication service.
-     *
-     * @param authService the authentication service implementation
-     */
-    public AuthController(AuthServiceImpl authService) {
-        this.authService = authService;
-    }
 
     /**
      * Registers a new user in the system.

--- a/src/main/java/ru/effectivemobile/taskmanagement/controller/TaskController.java
+++ b/src/main/java/ru/effectivemobile/taskmanagement/controller/TaskController.java
@@ -3,6 +3,9 @@ package ru.effectivemobile.taskmanagement.controller;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -11,8 +14,6 @@ import org.springframework.web.bind.annotation.*;
 import ru.effectivemobile.taskmanagement.dto.TaskRequestAdminDto;
 import ru.effectivemobile.taskmanagement.dto.TaskRequestUserDto;
 import ru.effectivemobile.taskmanagement.dto.TaskResponseDto;
-import ru.effectivemobile.taskmanagement.model.Role;
-import ru.effectivemobile.taskmanagement.model.User;
 import ru.effectivemobile.taskmanagement.service.TaskService;
 import ru.effectivemobile.taskmanagement.util.CurrentUserProvider;
 import ru.effectivemobile.taskmanagement.validation.OnCreate;
@@ -94,8 +95,9 @@ public class TaskController {
      */
     @GetMapping
     @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
-    public ResponseEntity<List<TaskResponseDto>> getAllTasks() {
-        return ResponseEntity.ok(taskService.getAllTasks());
+    public ResponseEntity<Page<TaskResponseDto>> getAllTasks(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(taskService.getAllTasks(pageable));
     }
 
     /**

--- a/src/main/java/ru/effectivemobile/taskmanagement/repository/TaskRepository.java
+++ b/src/main/java/ru/effectivemobile/taskmanagement/repository/TaskRepository.java
@@ -1,5 +1,7 @@
 package ru.effectivemobile.taskmanagement.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,7 +26,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
      * @return a list of tasks associated with the given user, or an empty list if no tasks are found
      */
     @Query("SELECT t FROM Task t WHERE t.author.id = :userId OR t.assignee.id = :userId")
-    Optional<List<Task>> findAllByAuthorAndAssignee(@Param("userId") Long userId);
+    Page<Task> findAllByAuthorAndAssignee(@Param("userId") Long userId, Pageable pageable);
 
     /**
      * Finds a task by its ID where the given user is both the author and the assignee of the task.

--- a/src/main/java/ru/effectivemobile/taskmanagement/service/TaskService.java
+++ b/src/main/java/ru/effectivemobile/taskmanagement/service/TaskService.java
@@ -1,5 +1,7 @@
 package ru.effectivemobile.taskmanagement.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import ru.effectivemobile.taskmanagement.dto.TaskRequestAdminDto;
 import ru.effectivemobile.taskmanagement.dto.TaskRequestUserDto;
 import ru.effectivemobile.taskmanagement.dto.TaskResponseDto;
@@ -93,4 +95,5 @@ public interface TaskService {
      *
      * @return a list of all tasks as response DTOs
      */
-    List<TaskResponseDto> getAllTasks();}
+    Page<TaskResponseDto> getAllTasks(Pageable pageable);
+}

--- a/src/main/java/ru/effectivemobile/taskmanagement/service/impl/TaskServiceImpl.java
+++ b/src/main/java/ru/effectivemobile/taskmanagement/service/impl/TaskServiceImpl.java
@@ -1,6 +1,8 @@
 package ru.effectivemobile.taskmanagement.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import ru.effectivemobile.taskmanagement.dto.TaskRequestAdminDto;
@@ -191,20 +193,17 @@ public class TaskServiceImpl implements TaskService {
      * @return A list of all task response DTOs.
      */
     @Override
-    public List<TaskResponseDto> getAllTasks() {
+    public Page<TaskResponseDto> getAllTasks(Pageable pageable) {
         User user = currentUserProvider.getCurrentUser();
-        List<Task> taskList = taskRepository.findAll();;
+        Page<Task> taskList = taskRepository.findAll(pageable);
 
         if (user.getRole().equals(Role.USER)) {
             // Retrieve all tasks for a user, throw an exception if not found.
-            taskList = taskRepository.findAllByAuthorAndAssignee(user.getId())
-                    .orElseThrow(() -> new TaskNotFoundException("No tasks found for user with id " + user.getId()));
+            taskList = taskRepository.findAllByAuthorAndAssignee(user.getId(), pageable);
         }
 
         // Convert each task to a response DTO and return the list.
-        return taskList.stream()
-                .map(TaskConverter::toDto)
-                .collect(Collectors.toList());
+        return taskList.map(TaskConverter::toDto);
     }
 
 

--- a/src/main/java/ru/effectivemobile/taskmanagement/util/TaskConverter.java
+++ b/src/main/java/ru/effectivemobile/taskmanagement/util/TaskConverter.java
@@ -12,7 +12,7 @@ public class TaskConverter {
      * Converts a TaskRequestDto object into a Task entity.
      *
      * @param dto       The TaskRequestDto object containing the task data.
-     * @param author    The author of the task (User object).
+     * @param admin    The author of the task (User object).
      * @param assignee  The assignee of the task (User object).
      * @return          The Task entity built from the provided DTO and user objects.
      */

--- a/src/test/java/ru/effectivemobile/taskmanagement/controller/TaskControllerTest.java
+++ b/src/test/java/ru/effectivemobile/taskmanagement/controller/TaskControllerTest.java
@@ -10,6 +10,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import ru.effectivemobile.taskmanagement.dto.TaskRequestAdminDto;
@@ -133,6 +137,10 @@ class TaskControllerTest {
             .assigneeEmail(user.getEmail())
             .build();
 
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<TaskResponseDto> pageUser = new PageImpl<>(List.of(responseUser), pageable, 1);
+    Page<TaskResponseDto> pageAdmin = new PageImpl<>(List.of(responseAdmin), pageable, 1);
+
     // POST TESTS USER CREATE
 
     @Test
@@ -228,21 +236,31 @@ class TaskControllerTest {
     @Test
     void getAllTasks() throws Exception {
         given(currentUserProvider.getCurrentUser()).willReturn(user);
-        given(taskService.getAllTasks()).willReturn(List.of(responseUser));
+        given(taskService.getAllTasks(any(Pageable.class))).willReturn(pageUser);
 
-        mockMvc.perform(get("/tasks"))
+        mockMvc.perform(get("/tasks?page=1&size=5"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(List.of(responseUser))));
+                .andExpect(jsonPath("$.content[0].title").value(responseUser.getTitle()))
+                .andExpect(jsonPath("$.content[0].description").value(responseUser.getDescription()))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(10));
     }
 
     @Test
     void getAllTasksAdmin() throws Exception {
         given(currentUserProvider.getCurrentUser()).willReturn(admin);
-        given(taskService.getAllTasks()).willReturn(List.of(responseAdmin));
+        given(taskService.getAllTasks(any(Pageable.class))).willReturn(pageAdmin);
 
-        mockMvc.perform(get("/tasks"))
+        mockMvc.perform(get("/tasks?page=1&size=5"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(List.of(responseAdmin))));
+                .andExpect(jsonPath("$.content[0].title").value(responseAdmin.getTitle()))
+                .andExpect(jsonPath("$.content[0].description").value(responseAdmin.getDescription()))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(10));
     }
 
     @Test
@@ -259,7 +277,7 @@ class TaskControllerTest {
     @Test
     void getAllTaskNotFound() throws Exception {
         given(currentUserProvider.getCurrentUser()).willReturn(user);
-        given(taskService.getAllTasks()).willThrow(new EntityNotFoundException("Entity not founded"));
+        given(taskService.getAllTasks(pageable)).willThrow(new EntityNotFoundException("Entity not founded"));
 
         mockMvc.perform(get("/taskss")
                         .contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
### Description
This pull request adds pagination to the `GET /tasks` endpoint. It allows clients to retrieve tasks in paginated format using `page` and `size` query parameters. This makes the API more efficient and scalable when dealing with large datasets.

### Changes Included
- Updated controller to handle pagination using `PageRequest`
- Updated service layer to return a `Page<TaskResponseDto>`
- Extended Swagger documentation with pagination parameters
- Added unit test for paginated response
